### PR TITLE
Fix PDF and TeX generation

### DIFF
--- a/apache/dockerfile
+++ b/apache/dockerfile
@@ -8,7 +8,9 @@ RUN apt update -y && apt install -y \
     libexpat1  \
     apache2-utils \
     ssl-cert \
-    libapache2-mod-wsgi-py3
+    libapache2-mod-wsgi-py3 \
+    pandoc \
+    texlive-xetex
 
 RUN echo "LoadModule wsgi_module /usr/lib/apache2/modules/mod_wsgi.so" >> ${HTTPD_CONF} \
  && echo "IncludeOptional conf.d/*.conf" >> ${HTTPD_CONF}


### PR DESCRIPTION
Hi!

I could not create PDFs or TeX documents with the vanilla setup.
This is because `pandoc` and `latex` are installed in the `rdmo` container but not in the `apache`-container.
However, it is the `apache` container which executes the user requests and therefore needs `pandoc` and `latex` to work correctly.

Feel free to merge or delete this PR, and if I shall add more details / info please let me know.

Best,
Helmuth