### PR TITLE
Fixed permission error. No sudo for Docker group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vol/
 docker-compose.yaml
 variables.local
+apache/dockerfile
+rdmo/dockerfile

--- a/apache/dockerfile_master
+++ b/apache/dockerfile_master
@@ -1,5 +1,7 @@
 FROM httpd:latest
 
+ARG UID=<UID>
+
 ENV HTTPD_CONF="/usr/local/apache2/conf/httpd.conf"
 
 RUN apt update -y && apt install -y \
@@ -18,7 +20,7 @@ RUN echo "LoadModule wsgi_module /usr/lib/apache2/modules/mod_wsgi.so" >> ${HTTP
 RUN mkdir -p /usr/local/apache2/conf.d
 COPY vhosts.conf /usr/local/apache2/conf.d/vhosts.conf
 
-RUN useradd -ms /bin/bash rdmo
+RUN useradd -m -u $UID -s /bin/bash rdmo
 RUN mkdir -p /var/www/html
 RUN mkdir -p /var/run/apache2
 

--- a/dc_master.yaml
+++ b/dc_master.yaml
@@ -31,6 +31,7 @@ services:
         build:
             context: ./apache
         container_name: <GLOBAL_PREFIX>apache
+        restart: "<RESTART_POLICY>"
         ports:
             - "<FINALLY_EXPOSED_PORT>:80"
         volumes:
@@ -46,6 +47,7 @@ services:
         build:
             context: ./postgres
         container_name: <GLOBAL_PREFIX>postgres
+        restart: "<RESTART_POLICY>"
         volumes:
             - postgres:/var/lib/postgresql/data
         env_file:
@@ -55,6 +57,7 @@ services:
         build:
             context: ./rdmo
         container_name: <GLOBAL_PREFIX>rdmo
+        restart: "<RESTART_POLICY>"
         depends_on:
             - postgres
         volumes:

--- a/makefile
+++ b/makefile
@@ -4,6 +4,14 @@ DC_TEMP="docker-compose.yaml"
 VARS_ENV=$(shell if [ -f variables.local ]; then echo variables.local; else echo variables.env; fi)
 GLOBAL_PREFIX=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=GLOBAL_PREFIX=).*")
 FINALLY_EXPOSED_PORT=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=FINALLY_EXPOSED_PORT=)[0-9]+")
+DOCKER_IN_GROUPS=$(shell groups | grep "docker")
+MYID=$(shell id -u)
+
+ifeq ($(strip $(DOCKER_IN_GROUPS)),)
+SUDO_CMD=sudo 
+else
+SUDO_CMD=
+endif
 
 all: preparations run_build tail_logs
 preps: preparations
@@ -23,13 +31,21 @@ preparations:
 		| sed 's|<FINALLY_EXPOSED_PORT>|${FINALLY_EXPOSED_PORT}|g' \
 		| sed 's|<VARIABLES_FILE>|${VARS_ENV}|g' \
 		> ${DC_TEMP}
+		
+	cat rdmo/dockerfile_master \
+    	| sed 's|<UID>|$(MYID)|g' \
+    	> rdmo/dockerfile
+ 
+	cat apache/dockerfile_master \
+    	| sed 's|<UID>|$(MYID)|g' \
+    	> apache/dockerfile
 
 run_build:
-	sudo docker-compose up --build -d
+	$(SUDO_CMD)docker-compose up --build -d
 
 run_remove:
-	sudo docker-compose down --rmi all
-	sudo docker-compose rm --force
+	$(SUDO_CMD)docker-compose down --rmi all
+	$(SUDO_CMD)docker-compose rm --force
 
 tail_logs:
-	sudo docker-compose logs -f
+	$(SUDO_CMD)docker-compose logs -f

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ DC_TEMP="docker-compose.yaml"
 VARS_ENV=$(shell if [ -f variables.local ]; then echo variables.local; else echo variables.env; fi)
 GLOBAL_PREFIX=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=GLOBAL_PREFIX=).*")
 FINALLY_EXPOSED_PORT=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=FINALLY_EXPOSED_PORT=)[0-9]+")
+RESTART_POLICY=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=RESTART_POLICY=).*")
 DOCKER_IN_GROUPS=$(shell groups | grep "docker")
 MYID=$(shell id -u)
 
@@ -29,6 +30,7 @@ preparations:
 		| sed 's|<CURDIR>|${CURDIR}|g' \
 		| sed 's|<GLOBAL_PREFIX>|${GLOBAL_PREFIX}|g' \
 		| sed 's|<FINALLY_EXPOSED_PORT>|${FINALLY_EXPOSED_PORT}|g' \
+		| sed 's|<RESTART_POLICY>|${RESTART_POLICY}|g' \
 		| sed 's|<VARIABLES_FILE>|${VARS_ENV}|g' \
 		> ${DC_TEMP}
 		

--- a/rdmo/dockerfile_master
+++ b/rdmo/dockerfile_master
@@ -1,5 +1,7 @@
 FROM debian:latest
 
+ARG UID=<UID>
+
 ENV PATH=/opt:${PATH}
 
 RUN apt update -y && apt install -y \
@@ -28,7 +30,7 @@ RUN apt install -y \
 
 COPY ./rootfs /
 
-RUN useradd -ms /bin/bash rdmo
+RUN useradd -m -u $UID -s /bin/bash rdmo
 USER rdmo
 
 CMD ["/drun.sh"]

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ During build four folders later used as volumes will be created under `vol/`. Th
 
     Please note that you might need to change the `ALLOWED_HOSTS` entry depending on your server setup. The URL or IP under which RDMO is served needs to be allowed by putting it into the list. Usually the allowed hosts are declared in the `local.py`. In this docker compose setup we decided to move it into the environment variables and so the `variables.env` to raise awareness that the setting might need to be adjusted.
 
+    It is possible to change the restart policy of all three Docker services via changing the `RESTART_POLICY` variable.
+
 1. Build by running `make`
 
 1. Maybe create an RDMO user

--- a/variables.env
+++ b/variables.env
@@ -1,6 +1,9 @@
 # these are to modify the docker-compose.yaml
 GLOBAL_PREFIX=rdc-
 FINALLY_EXPOSED_PORT=8484
+# Docker restart policy (no, on-failure, always, unless-stopped)
+# see https://docs.docker.com/compose/compose-file/#restart
+RESTART_POLICY=no
 
 # settings inside the containers
 VOL=/vol


### PR DESCRIPTION
When we tried to install RDMO on a VM with multiple users, we weren't able to populate the "vol/" directory because it was created under a different user id. This doesn't pose a problem, when the vm's user id and the docker user id (1000) are equal. We added the user id as an argument to the dockerfiles.
Also in our installation, the user running docker-compose was part of the "docker" group so no sudo was needed. We added an option for the makefile to not use sudo when this is the case.