### PR TITLE
Change apache/vhosts.conf to use python 3.7 site packages

### DIFF
--- a/apache/vhosts.conf
+++ b/apache/vhosts.conf
@@ -8,7 +8,7 @@
     </Directory>
 
     WSGIDaemonProcess rdmo user=rdmo group=rdmo processes=2 \
-        python-path=/vol/rdmo-app:/vol/ve/lib/python3.5/site-packages
+        python-path=/vol/rdmo-app:/vol/ve/lib/python3.7/site-packages
 
     WSGIProcessGroup rdmo
     WSGIScriptAlias / /vol/rdmo-app/config/wsgi.py process-group=rdmo


### PR DESCRIPTION
Change apache/vhosts.conf to use python 3.7 site packages instead of python 3.5 to make the container work.

See [comment by AlexCosa-Linan](https://github.com/rdmorganiser/rdmo-docker-compose/issues/6#issuecomment-516076359) in issue #6