### PR TITLE
Enable ip adress and port configuration in DC

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ DC_MASTER="dc_master.yaml"
 DC_TEMP="docker-compose.yaml"
 VARS_ENV=$(shell if [ -f variables.local ]; then echo variables.local; else echo variables.env; fi)
 GLOBAL_PREFIX=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=GLOBAL_PREFIX=).*")
-FINALLY_EXPOSED_PORT=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=FINALLY_EXPOSED_PORT=)[0-9]+")
+FINALLY_EXPOSED_PORT=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=FINALLY_EXPOSED_PORT=)[.:0-9]+")
 RESTART_POLICY=$(shell cat ${CURDIR}/${VARS_ENV} | grep -Po "(?<=RESTART_POLICY=).*")
 DOCKER_IN_GROUPS=$(shell groups | grep "docker")
 MYID=$(shell id -u)

--- a/rdmo/rootfs/drun.sh
+++ b/rdmo/rootfs/drun.sh
@@ -11,7 +11,7 @@ function waitforpg() {
 
 waitforpg
 
-if [[ $(pip freeze | grep -Poc "^rdmo==") == "0" ]]; then
+if [ $(pip freeze | grep -Poc "^rdmo==") -eq 0 ] && [ $(pip freeze | grep -Poc "^rdmo @") -eq 0 ]; then
     /opt/install-rdmo.sh
 else
     echo "Won't do anything because RDMO is already installed."


### PR DESCRIPTION
In order to bind port to specific ip-adress such as the localhost including a port, this PR extends the regular expression used in the makefile.