### PR TITLE
chore: install rdmo[postgres] optional dependency

### DIFF
--- a/docker/rdmo/Dockerfile
+++ b/docker/rdmo/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt upgrade -y && apt install -y \
 RUN rm "$(find /usr/lib/python3.??/ -regex ".*EXTERNALLY-MANAGED.*")"
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN pip3 install --upgrade pip wheel setuptools
+RUN python -m pip install --upgrade pip wheel setuptools
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
@@ -42,7 +42,6 @@ RUN apt update && apt install -y \
 RUN apt update && apt install -y \
     libpq-dev \
   && rm -rf /var/lib/apt/lists/*
-RUN pip3 install psycopg2
 
 # for document export
 RUN apt update && apt install -y \
@@ -64,6 +63,6 @@ RUN chown -R "${USER}:${USER}" "${HOME}"
 USER "${USER}"
 
 RUN if [ -n "${RDMO_INSTALL_URL}" ]; then \
-    pip install "${RDMO_INSTALL_URL}"; else pip install rdmo; fi
+    python -m pip install "${RDMO_INSTALL_URL}"; else python -m pip install rdmo[postgres]; fi
 
 CMD ["/drun.sh"]


### PR DESCRIPTION
Hi @triole,

rdmo 2.0.0 can be installed with optional dependencies like `pip install rdmo[postgres]`. No need for pip installing `psycopg2` separately.

Sometimes you used pip3 and pip in the dockerfile, I switched them all to `python -m pip`.

I was unsure about the rdmo url yet:

Will this syntax work? 
`python -m pip install "${RDMO_INSTALL_URL}"[postgres]`